### PR TITLE
feat: add macOS support (cli)

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -214,6 +214,46 @@ jobs:
           asset_path: ./public/publish-zip/linker-linux-musl-arm64.zip
           asset_name: linker-linux-musl-arm64.zip
           asset_content_type: application/zip
+      - name: upload-osx-x64-oss
+        id: upload-osx-x64-oss
+        uses: tvrcgo/oss-action@v0.1.1
+        with:
+          region: oss-cn-shenzhen
+          key-id: ${{ secrets.ALIYUN_OSS_ID }}
+          key-secret: ${{ secrets.ALIYUN_OSS_SECRET }}
+          bucket: ide-qbcode
+          asset-path: ./public/publish-zip/linker-osx-x64.zip
+          target-path: /downloads/linker/v1.9.7/linker-osx-x64.zip
+      - name: upload-osx-x64
+        id: upload-osx-x64
+        uses: actions/upload-release-asset@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./public/publish-zip/linker-osx-x64.zip
+          asset_name: linker-osx-x64.zip
+          asset_content_type: application/zip
+      - name: upload-osx-arm64-oss
+        id: upload-osx-arm64-oss
+        uses: tvrcgo/oss-action@v0.1.1
+        with:
+          region: oss-cn-shenzhen
+          key-id: ${{ secrets.ALIYUN_OSS_ID }}
+          key-secret: ${{ secrets.ALIYUN_OSS_SECRET }}
+          bucket: ide-qbcode
+          asset-path: ./public/publish-zip/linker-osx-arm64.zip
+          target-path: /downloads/linker/v1.9.7/linker-osx-arm64.zip
+      - name: upload-osx-arm64
+        id: upload-osx-arm64
+        uses: actions/upload-release-asset@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./public/publish-zip/linker-osx-arm64.zip
+          asset_name: linker-osx-arm64.zip
+          asset_content_type: application/zip
       - name: upload-version-oss
         id: upload-version-oss
         uses: tvrcgo/oss-action@v0.1.1

--- a/shells/publish-macos.sh
+++ b/shells/publish-macos.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Linker macOS 发布脚本
+# 用于构建 macOS 控制台客户端 (osx-x64 和 osx-arm64)
+# 注意: 此脚本应在 macOS 上运行以获得最佳兼容性
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+cd "$PROJECT_ROOT"
+
+# 清理和创建目录
+rm -rf public/extends/osx-x64
+rm -rf public/extends/osx-arm64
+rm -rf public/publish/osx-x64
+rm -rf public/publish/osx-arm64
+mkdir -p public/publish-zip
+
+# 构建 Web 前端
+echo "Building web frontend..."
+cd src/linker.web
+npm install
+npm run build
+cd "$PROJECT_ROOT"
+
+# 复制版本文件
+cp shells/version.txt public/version.txt
+
+# macOS 发布配置
+PUBLISH_OPTS="-c release -f net8.0 -p:PublishSingleFile=true --self-contained true -p:TrimMode=partial -p:TieredPGO=true -p:DebugType=full -p:EventSourceSupport=false -p:DebugSymbols=true -p:EnableCompressionInSingleFile=true -p:DebuggerSupport=false -p:EnableUnsafeBinaryFormatterSerialization=false -p:EnableUnsafeUTF7Encoding=false -p:HttpActivityPropagationSupport=false -p:InvariantGlobalization=true -p:MetadataUpdaterSupport=false -p:UseSystemResourceKeys=true -p:MetricsSupport=false -p:StackTraceSupport=false -p:XmlResolverIsNetworkingEnabledByDefault=false"
+
+# 发布 osx-arm64 (Apple Silicon)
+echo "Publishing osx-arm64 (Apple Silicon)..."
+dotnet publish src/linker $PUBLISH_OPTS -r osx-arm64 -o public/publish/osx-arm64/linker-osx-arm64
+
+# 复制 Apple Silicon 原生库
+cp src/linker/libutunshim-arm64.dylib public/publish/osx-arm64/linker-osx-arm64/libutunshim.dylib 2>/dev/null || true
+
+# 复制通用扩展文件
+cp -r public/extends/any/* public/publish/osx-arm64/linker-osx-arm64/ 2>/dev/null || true
+
+# 打包
+cd public/publish/osx-arm64
+zip -r ../../publish-zip/linker-osx-arm64.zip .
+cd "$PROJECT_ROOT"
+
+# 发布 osx-x64 (Intel Mac)
+echo "Publishing osx-x64 (Intel Mac)..."
+dotnet publish src/linker $PUBLISH_OPTS -r osx-x64 -o public/publish/osx-x64/linker-osx-x64
+
+# 复制 Intel 原生库
+cp src/linker/libutunshim.dylib public/publish/osx-x64/linker-osx-x64/libutunshim.dylib 2>/dev/null || true
+
+# 复制通用扩展文件
+cp -r public/extends/any/* public/publish/osx-x64/linker-osx-x64/ 2>/dev/null || true
+
+# 打包
+cd public/publish/osx-x64
+zip -r ../../publish-zip/linker-osx-x64.zip .
+cd "$PROJECT_ROOT"
+
+echo ""
+echo "=========================================="
+echo "macOS builds completed successfully!"
+echo "=========================================="
+echo "Output files:"
+echo "  - public/publish-zip/linker-osx-arm64.zip (Apple Silicon)"
+echo "  - public/publish-zip/linker-osx-x64.zip (Intel Mac)"
+echo ""
+

--- a/shells/publish.bat
+++ b/shells/publish.bat
@@ -40,3 +40,19 @@ for %%r in (win-x86,win-x64,win-arm64,linux-x64,linux-arm,linux-arm64,linux-musl
 
 	7z a -tzip ./public/publish-zip/linker-%%r.zip ./public/publish/%%r/*
 )
+
+REM macOS builds (osx-x64 for Intel, osx-arm64 for Apple Silicon)
+REM Copy native libraries to extends directory first
+mkdir public\extends\osx-x64\linker-osx-x64 2>nul
+mkdir public\extends\osx-arm64\linker-osx-arm64 2>nul
+echo F|xcopy "src\linker\libutunshim.dylib" "public\extends\osx-x64\linker-osx-x64\libutunshim.dylib" /f /h /y
+echo F|xcopy "src\linker\libutunshim-arm64.dylib" "public\extends\osx-arm64\linker-osx-arm64\libutunshim.dylib" /f /h /y
+
+for %%r in (osx-x64,osx-arm64) do (
+	dotnet publish src/linker -c release -f net8.0 -o public/publish/%%r/linker-%%r  -r %%r  -p:PublishSingleFile=true  --self-contained true  -p:TrimMode=partial -p:TieredPGO=true  -p:DebugType=full -p:EventSourceSupport=false -p:DebugSymbols=true -p:EnableCompressionInSingleFile=true -p:DebuggerSupport=false -p:EnableUnsafeBinaryFormatterSerialization=false -p:EnableUnsafeUTF7Encoding=false -p:HttpActivityPropagationSupport=false -p:InvariantGlobalization=true  -p:MetadataUpdaterSupport=false  -p:UseSystemResourceKeys=true -p:MetricsSupport=false -p:StackTraceSupport=false -p:XmlResolverIsNetworkingEnabledByDefault=false
+
+	echo F|xcopy "public\\extends\\%%r\\linker-%%r\\*" "public\\publish\\%%r\\linker-%%r\\*"  /s /f /h /y
+	echo F|xcopy "public\\extends\\any\\*" "public\\publish\\%%r\\linker-%%r\\*"  /s /f /h /y
+
+	7z a -tzip ./public/publish-zip/linker-%%r.zip ./public/publish/%%r/*
+)

--- a/src/linker.tun/LinkerTunDeviceAdapter.cs
+++ b/src/linker.tun/LinkerTunDeviceAdapter.cs
@@ -76,7 +76,6 @@ namespace linker.tun
                     linkerTunDevice = new LinkerLinuxTunDevice();
                     return true;
                 }
-
                 else if (OperatingSystem.IsMacOS())
                 {
                     linkerTunDevice = new LinkerOsxTunDevice();

--- a/src/linker.tunnel/connection/TunnelConnectionUdp.cs
+++ b/src/linker.tunnel/connection/TunnelConnectionUdp.cs
@@ -6,7 +6,6 @@ using System.Text;
 using System.Text.Json.Serialization;
 using System.Net.Sockets;
 using System.IO.Pipelines;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace linker.tunnel.connection
 {

--- a/src/linker/linker.csproj
+++ b/src/linker/linker.csproj
@@ -80,6 +80,14 @@
 		<None Update="msquic.dll" Condition="'$(RuntimeIdentifier)'=='win-x64' or '$(RuntimeIdentifier)'=='win-arm64'">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
+		<!-- macOS native libraries -->
+		<None Update="libutunshim.dylib" Condition="'$(RuntimeIdentifier)'=='osx-x64'">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="libutunshim-arm64.dylib" Condition="'$(RuntimeIdentifier)'=='osx-arm64'">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<Link>libutunshim.dylib</Link>
+		</None>
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="System.ServiceProcess.ServiceController" Version="8.0.1" />


### PR DESCRIPTION
## Add macOS Support (Intel & Apple Silicon)

### Changes

- ✅ Add macOS native library configuration (`libutunshim.dylib`)
- ✅ Add macOS publish script (`shells/publish-macos.sh`)
- ✅ Update GitHub Actions workflow for macOS builds
- ✅ Update Windows publish script to support macOS cross-compilation

### Platform Support

- **macOS Intel** (osx-x64)
- **macOS Apple Silicon** (osx-arm64)

### Build & Publish

```bash
# Local build (on macOS)
./shells/publish-macos.sh

# Or manually
dotnet publish src/linker -c Release -r osx-arm64 -f net8.0 --self-contained true
```

### Technical Details

- Native library (`libutunshim.dylib`) copied via publish scripts

### Testing

- [x] Local build on Apple Silicon M3
- [x] Runtime verification with TUN device on Apple Silicon M3
